### PR TITLE
libstsound: fix magic constant for YM3b format

### DIFF
--- a/libstsound/Ymload.cpp
+++ b/libstsound/Ymload.cpp
@@ -308,7 +308,7 @@ ymbool	CYmMusic::ymDecode(void)
 				pSongPlayer = strdup("YM-Chip driver.");
 				break;
 
-			case 0x594D3262: // 'YM3b':		// Standart YM-Atari format + Loop info.
+			case 0x594D3362: // 'YM3b':		// Standart YM-Atari format + Loop info.
 				pUD = (ymu8*)(pBigMalloc+fileSize-4);
 				songType = YM_V3;
 				nbFrame = (fileSize-4)/14;


### PR DESCRIPTION
0x32 is '2', not '3', so this was looking for 'YM2b' instead of 'YM3b'.