### PR TITLE
libstsound: changes to make update (and thereby ymMusicCompute) usable

### DIFF
--- a/libstsound/StSoundLibrary.h
+++ b/libstsound/StSoundLibrary.h
@@ -57,7 +57,8 @@ extern	void		ymMusicDestroy(YMMUSIC *pMusic);
 extern	ymbool			ymMusicLoad(YMMUSIC *pMusic,const char *fName);						// Method 1 : Load file using stdio library (fopen/fread, etc..)
 extern	ymbool			ymMusicLoadMemory(YMMUSIC *pMusic,void *pBlock,ymu32 size);			// Method 2 : Load file from a memory block
 
-extern	ymbool			ymMusicCompute(YMMUSIC *pMusic,ymsample *pBuffer,ymint nbSample);	// Render nbSample samples of current YM tune into pBuffer PCM 16bits mono sample buffer.
+extern	ymbool			ymMusicIsMono(YMMUSIC *pMusic);
+extern	ymbool			ymMusicCompute(YMMUSIC *pMusic,ymsample *pBuffer,ymint nbSample);	// Render nbSample samples of current YM tune into pBuffer PCM 16bits sample buffer.
 
 extern	void			ymMusicSetLoopMode(YMMUSIC *pMusic,ymbool bLoop);
 extern	const char	*	ymMusicGetLastError(YMMUSIC *pMusic);

--- a/libstsound/YmMusic.cpp
+++ b/libstsound/YmMusic.cpp
@@ -226,8 +226,8 @@ ymint	vblNbSample;
 				}
 				if (sampleToCompute>0)
 				{
-//					ymChip.update(pOut,sampleToCompute);	// YM Emulation.
-					pOut += sampleToCompute;
+					ymChip.updateStereo(pOut,sampleToCompute);	// YM Emulation.
+					pOut += sampleToCompute * 2;
 				}
 				nbs -= sampleToCompute;
 			}

--- a/libstsound/YmMusic.cpp
+++ b/libstsound/YmMusic.cpp
@@ -162,6 +162,12 @@ ymint		CYmMusic::getAttrib(void)
 		return attrib;
 }
 
+ymbool		CYmMusic::isMono(void)
+{
+		return ((songType >= YM_TRACKER1) && (songType < YM_TRACKERMAX)) ||
+			((songType >= YM_MIX1) && (songType < YM_MIXMAX));
+}
+
 ymbool	CYmMusic::isSeekable(void)
 {
 		return getAttrib()&A_TIMECONTROL;

--- a/libstsound/YmMusic.h
+++ b/libstsound/YmMusic.h
@@ -131,6 +131,7 @@ public:
 	ymbool	loadMemory(void *pBlock,ymu32 size);
 
 	void	unLoad(void);
+	ymbool	isMono(void);
 	ymbool	isSeekable(void);
 	ymbool	update(ymsample *pBuffer,ymint nbSample);
 	ymu32	getPos(void);

--- a/libstsound/YmUserInterface.cpp
+++ b/libstsound/YmUserInterface.cpp
@@ -107,6 +107,12 @@ void	ymMusicStop(YMMUSIC *_pMus)
 	pMusic->stop();
 }
 
+ymbool	ymMusicIsMono(YMMUSIC *pMus)
+{
+	CYmMusic *pMusic = (CYmMusic*)pMus;
+	return pMusic->isMono() ? YMTRUE : YMFALSE;
+}
+
 ymbool		ymMusicIsSeekable(YMMUSIC *_pMus)
 {
 	CYmMusic *pMusic = (CYmMusic*)_pMus;


### PR DESCRIPTION
Firstly, actually emit samples when doing YM emulation, to actually get sound out from those kinds of files.

Secondly, since that outputs stereo instead of mono, expose that information so that the user knows what kind of samples to expect.