### PR TITLE
libstsound: C binding fixes

### DIFF
--- a/libstsound/StSoundLibrary.h
+++ b/libstsound/StSoundLibrary.h
@@ -34,6 +34,10 @@
 
 #include "YmTypes.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef	void			YMMUSIC;
 
 typedef struct
@@ -70,5 +74,9 @@ extern	void			ymMusicStop(YMMUSIC *pMusic);
 extern	ymbool			ymMusicIsSeekable(YMMUSIC *pMusic);
 extern	ymu32			ymMusicGetPos(YMMUSIC *pMusic);
 extern	void			ymMusicSeek(YMMUSIC *pMusic,ymu32 timeInMs);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/libstsound/YmUserInterface.cpp
+++ b/libstsound/YmUserInterface.cpp
@@ -59,7 +59,7 @@ void	ymMusicDestroy(YMMUSIC *pMus)
 	delete pMusic;
 }
 
-ymbool	ymMusicCompute(YMMUSIC *_pMus,ymsample *pBuffer,int nbSample)
+ymbool	ymMusicCompute(YMMUSIC *_pMus,ymsample *pBuffer,ymint nbSample)
 {
 	CYmMusic *pMusic = (CYmMusic*)_pMus;
 	return pMusic->update(pBuffer,nbSample);

--- a/libstsound/YmUserInterface.cpp
+++ b/libstsound/YmUserInterface.cpp
@@ -29,6 +29,7 @@
 -----------------------------------------------------------------------------*/
 
 
+#include <new>
 #include "YmMusic.h"
 #include "StSoundLibrary.h"
 
@@ -37,7 +38,7 @@ extern "C" {
 
 YMMUSIC	*	ymMusicCreate()
 {
-	return (YMMUSIC*)(new CYmMusic);
+	return (YMMUSIC*)new (std::nothrow) CYmMusic;
 }
 
 

--- a/libstsound/YmUserInterface.cpp
+++ b/libstsound/YmUserInterface.cpp
@@ -33,7 +33,7 @@
 #include "StSoundLibrary.h"
 
 
-// Static assert to check various type len
+extern "C" {
 
 YMMUSIC	*	ymMusicCreate()
 {
@@ -129,4 +129,6 @@ void		ymMusicSeek(YMMUSIC *_pMus,ymu32 timeInMs)
 	{
 		pMusic->setMusicTime(timeInMs);
 	}
+}
+
 }


### PR DESCRIPTION
At least, I assume that the functions in `StSoundLibrary.h` were meant to be C bindings. Currently they're just C++ wrapper functions since they aren't `extern "C"`.