### PR TITLE
Support floating point variables when listing Basic files

### DIFF
--- a/iDSK/src/Basic.cpp
+++ b/iDSK/src/Basic.cpp
@@ -220,6 +220,15 @@ void Basic( BYTE * BufFile, char * Listing, bool IsBasic, bool CrLf )
                                     strcat( Listing, "$" );
                                     break;
 
+                                case 0x04 : // Variable float (type !)
+                                    Pos = AddWord( BufFile
+                                                 , 2 + Pos
+                                                 , Listing
+                                                 , Deprotect
+                                                 );
+                                    strcat( Listing, "!" );
+                                    break;
+
                                 case 0x0B :
                                 case 0x0C :
                                 case 0x0D : // Variable "standard"

--- a/iDSK/src/Main.cpp
+++ b/iDSK/src/Main.cpp
@@ -21,7 +21,7 @@ int main(int argc, char** argv) {
        ModeDisaFile, ModeListBasic, 
        ModeListDams,ModeListHex, 
        ModeGetFile, ModeNewDsk, Force_Overwrite,
-	Read_only, System_file;
+       Read_only, System_file, Split_lines;
        
   ModeListDsk =  ModeImportFile =
   ModeRemoveFile  = ModeDisaFile = 
@@ -78,6 +78,7 @@ int main(int argc, char** argv) {
 	>> OptionPresent('f',"force",Force_Overwrite)
 	>> OptionPresent('o',"write-protect",Read_only)
 	>> OptionPresent('s',"system",System_file)
+  >> OptionPresent('p',"split-lines",Split_lines)
 	>> Option('u',"user",UserNumber)
 	;
 
@@ -118,7 +119,7 @@ int main(int argc, char** argv) {
 		MyDsk.OnViewFic(Indice);
 	
 		if ( ModeListBasic ) 
-			cout << ViewBasic( ) << endl;
+			cout << ViewBasic( Split_lines ) << endl;
 		else if ( ModeListDams )
 			cout << "Not yet coded ! Please try a newer version of iDSK ! Sorry !"<<endl;
 		else if ( ModeListHex ) {
@@ -267,7 +268,8 @@ void help(void)
   cout << "-r : Remove file                       iDSK floppy.dsk -r myprog.bas" << endl;
   cout << "-n : create New dsk file               iDSK floppy2.dsk -n" << endl;
   cout << "-z : disassemble a binary file         iDSK floppy.dsk -z myprog.bin" << endl;
-  cout << "-b : list a Basic file                 iDSK floppy.dsk -b myprog.bas" << endl;
+  cout << "-b : list a Basic file                 iDSK floppy.dsk -b myprog.bas" << endl
+       << " -p : split lines after 80 char             ... -p" << endl;
   cout << "-d : list a Dams file                  iDSK floppy.dsk -d myprog.dms" << endl;
   cout << "-h : list a binary file as Hexadecimal iDSK floppy.dsk -h myprog.bin" << endl;
   cout << "-i : Import file                       iDSK floppy.dsk -i myprog.bas" << endl

--- a/iDSK/src/ViewFile.cpp
+++ b/iDSK/src/ViewFile.cpp
@@ -16,7 +16,6 @@ string ViewDams(  )
 	//cout << Listing << endl;
 }
 
-
 string ViewDesass( )
 {
 	cerr << "Taille du fichier : " << TailleFic << endl;
@@ -24,13 +23,13 @@ string ViewDesass( )
     return Listing;
 	//cout << Listing << endl;
 }
-string ViewBasic( )
+
+string ViewBasic( bool AddCrLf )
 {
 	bool IsBasic=true;
 	//cout << "Entre Ici\n";
 	cerr << "Taille du fichier : " << TailleFic << endl;
-	Basic( BufFile, Listing, IsBasic, true );
+	Basic( BufFile, Listing, IsBasic, AddCrLf );
 	//cout << Listing << endl;
 	return Listing;
-	
 }

--- a/iDSK/src/ViewFile.h
+++ b/iDSK/src/ViewFile.h
@@ -1,13 +1,9 @@
 #ifndef __VIEWFILE_H__
 #define __VIEWFILE_H__
 
-
-
-
 string ViewDams();
 string ViewLine();
 string ViewDesass();
-string ViewBasic();
+string ViewBasic( bool AddCrLf );
 	
-
 #endif


### PR DESCRIPTION
This patch fixes an issue that occurs when listing Basic files that use floating point variables (suffixed with a !).