### PR TITLE
Update cmake requirements for latest version

### DIFF
--- a/cpctools/CMakeLists.txt
+++ b/cpctools/CMakeLists.txt
@@ -1,5 +1,5 @@
+cmake_minimum_required(VERSION 3.10)
 project (CPCTools)
-cmake_minimum_required(VERSION 3.0)
 
 include(CheckIncludeFileCXX)
 include(CheckCCompilerFlag)

--- a/cpctools/CMakeLists.txt
+++ b/cpctools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.0...3.10)
 project (CPCTools)
 
 include(CheckIncludeFileCXX)

--- a/cpctools/tools/AFT2/CMakeLists.txt
+++ b/cpctools/tools/AFT2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 2.8...3.10)
 project(AFT2)
 
 set(librs232 RS232)

--- a/cpctools/tools/AFT2/CMakeLists.txt
+++ b/cpctools/tools/AFT2/CMakeLists.txt
@@ -1,5 +1,5 @@
+cmake_minimum_required(VERSION 3.10)
 project(AFT2)
-cmake_minimum_required(VERSION 2.8)
 
 set(librs232 RS232)
 set(libaft libaft)


### PR DESCRIPTION
cmake_minimum_required needed to be updated to correct the following error:

```
CMake Error at CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```

Build results now:
```
…/cpctools/build on  master ✦ 🔋 100% ❯ cmake ../cpctools
-- The C compiler identification is GNU 13.3.0
-- The CXX compiler identification is GNU 13.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test COMPILER_HAS_WNO_MULTICHAR
-- Performing Test COMPILER_HAS_WNO_MULTICHAR - Success
-- Looking for C++ include libdsk.h
-- Looking for C++ include libdsk.h - found
-- Looking for strcasecmp
-- Looking for strcasecmp - found
-- Configuring done (0.6s)
-- Generating done (0.0s)
-- Build files have been written to: /home/cormac/devel/cpctools/build
```

Cmake version:

```
…/cpctools/build on  master [?] via △ v4.0.2 ✦ 🔋 100% ❯ cmake --version
cmake version 4.0.2

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```
